### PR TITLE
Fix typos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-# for container-y googdness:
+# for container-y goodness:
 sudo: false
 
 python:

--- a/docs/description.txt
+++ b/docs/description.txt
@@ -6,5 +6,5 @@ This is done by combining several callables into a re-usable
 runner. Those callables may produce or require resource objects which
 mush passes between them based on the type of the object. The
 callables are called roughly in the order they are added to the
-runner, but adjusted for the resources required or procuced by it.
+runner, but adjusted for the resources required or produced by it.
  

--- a/docs/development.txt
+++ b/docs/development.txt
@@ -41,7 +41,7 @@ Building the documentation
 --------------------------
 
 The Sphinx documentation is built by doing the following from the
-directory containg setup.py::
+directory containing setup.py::
 
   $ cd docs
   $ make html

--- a/docs/installation.txt
+++ b/docs/installation.txt
@@ -1,7 +1,7 @@
 Installation Instructions
 =========================
 
-The easyiest way to install Mush is::
+The easiest way to install Mush is::
 
   pip install mush
 

--- a/docs/use.txt
+++ b/docs/use.txt
@@ -369,7 +369,7 @@ configured to use the types from that mapping:
   runner.add(desperation, returns=returns_mapping())
   runner.add(juicer, requires(Apple, Orange))
 
-One again, we can happily make juice out of vegetables:
+Once again, we can happily make juice out of vegetables:
 
 >>> runner()
 I sold vegetables as fruit

--- a/mush/tests/test_declarations.py
+++ b/mush/tests/test_declarations.py
@@ -98,7 +98,7 @@ class TestItem(TestCase):
 
 class TestHow(TestCase):
 
-    def test_proccess_on_base(self):
+    def test_process_on_base(self):
         compare(how('foo').process('bar'), missing)
 
 


### PR DESCRIPTION
  * `procuced` -> `produced`
  * `containg` -> `containing`
  * `easyiest` -> `easiest`
  * `One` -> `Once`
  * `proccess` -> `process`
  * `googdness` -> `goodness`
